### PR TITLE
Fix #15

### DIFF
--- a/R/fd_chull.R
+++ b/R/fd_chull.R
@@ -8,6 +8,6 @@ fd_chull <- function(traits) {
     return(NA_real_)
   }
 
-  return(geometry::convhulln(traits, "FA")$vol)
+  return(geometry::convhulln(traits, "FA"))
 
 }

--- a/R/fd_chull.R
+++ b/R/fd_chull.R
@@ -4,8 +4,22 @@ fd_chull <- function(traits) {
 
   traits <- traits[!duplicated(traits),, drop = FALSE]
 
+  if (ncol(traits) == 1L) {
+   return(list(
+     "hull" = c(which.min(traits), which.max(traits)),
+     "area" = max(traits) - min(traits),
+     "vol" = max(traits) - min(traits),
+     p = traits
+   ))
+  }
+
   if (nrow(traits) <= ncol(traits)) {
-    return(NA_real_)
+    return(list(
+      "hull" = seq_len(nrow(traits)),
+      "area" = NA_real_,
+      "vol" = NA_real_,
+      p = traits
+    ))
   }
 
   return(geometry::convhulln(traits, "FA"))

--- a/R/fd_chull.R
+++ b/R/fd_chull.R
@@ -1,0 +1,13 @@
+# A wrapper around geometry::convhulln() to properly handle errors and specific
+# cases
+fd_chull <- function(traits) {
+
+  traits <- traits[!duplicated(traits),, drop = FALSE]
+
+  if (nrow(traits) <= ncol(traits)) {
+    return(NA_real_)
+  }
+
+  return(geometry::convhulln(traits, "FA")$vol)
+
+}

--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -54,7 +54,11 @@ fd_fdiv <- function(traits, sp_com) {
     # Select traits for species actually in site
     sub_traits <- traits[names(sub_site),, drop = FALSE]
 
-    G <- colMeans(sub_traits)
+    ch <- fd_chull(sub_traits)
+
+    verts <- ch$p[unique(c(ch$hull))]
+
+    G <- colMeans(verts)
 
     dG <- sqrt(colSums((t(sub_traits) - G)^2))
 

--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -56,7 +56,7 @@ fd_fdiv <- function(traits, sp_com) {
 
     ch <- fd_chull(sub_traits)
 
-    verts <- ch$p[unique(c(ch$hull))]
+    verts <- ch$p[unique(c(ch$hull)),, drop = FALSE]
 
     G <- colMeans(verts)
 

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -80,28 +80,14 @@ fd_fric <- function(traits, sp_com, stand = FALSE) {
   } else {
 
     if (stand) {
-      max_range <- fd_fric_single(traits)
+      max_range <- fd_chull(traits)
     }
 
     fric_site <- apply(sp_com, 1, function(site_row) {
-      fd_fric_single(traits[site_row > 0,, drop = FALSE])
+      fd_chull(traits[site_row > 0,, drop = FALSE])
     })
   }
 
   data.frame(site = rownames(sp_com), FRic = fric_site/max_range,
              row.names = NULL)
-}
-
-# A wrapper around geometry::convhulln() to properly handle errors and specific
-# cases
-fd_fric_single <- function(traits) {
-
-  traits <- traits[!duplicated(traits),, drop = FALSE]
-
-  if (nrow(traits) <= ncol(traits)) {
-    return(NA_real_)
-  }
-
-  return(geometry::convhulln(traits, "FA")$vol)
-
 }

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -80,11 +80,11 @@ fd_fric <- function(traits, sp_com, stand = FALSE) {
   } else {
 
     if (stand) {
-      max_range <- fd_chull(traits)
+      max_range <- fd_chull(traits)$vol
     }
 
     fric_site <- apply(sp_com, 1, function(site_row) {
-      fd_chull(traits[site_row > 0,, drop = FALSE])
+      fd_chull(traits[site_row > 0,, drop = FALSE])$vol
     })
   }
 

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -66,27 +66,13 @@ fd_fric <- function(traits, sp_com, stand = FALSE) {
 
   max_range <- 1
 
-  if (ncol(traits) == 1L) {
-
-    if (stand) {
-      max_range <- max(traits) - min(traits)
-    }
-
-    fric_site <- apply(sp_com, 1, function(site_row) {
-      traits_site <- traits[site_row > 0,]
-      return(max(traits_site) - min(traits_site))
-    })
-
-  } else {
-
-    if (stand) {
-      max_range <- fd_chull(traits)$vol
-    }
-
-    fric_site <- apply(sp_com, 1, function(site_row) {
-      fd_chull(traits[site_row > 0,, drop = FALSE])$vol
-    })
+  if (stand) {
+    max_range <- fd_chull(traits)$vol
   }
+
+  fric_site <- apply(sp_com, 1, function(site_row) {
+    fd_chull(traits[site_row > 0,, drop = FALSE])$vol
+  })
 
   data.frame(site = rownames(sp_com), FRic = fric_site/max_range,
              row.names = NULL)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fd_fric(traits_birds)
 # Compute Functional Divergence
 fd_fdiv(traits_birds)
 #>   site      FDiv
-#> 1   s1 0.6011971
+#> 1   s1 0.7282172
 
 # Compute Rao's Quadratic Entropy
 fd_raoq(traits_birds)

--- a/tests/testthat/test-fdiv.R
+++ b/tests/testthat/test-fdiv.R
@@ -12,7 +12,7 @@ test_that("Functional Divergence output format", {
   expect_equal(nrow(fdiv), 1)
   expect_equal(colnames(fdiv), c("site", "FDiv"))
 
-  expect_equal(fd_fdiv(traits_birds)$FDiv, 0.6011971, tolerance = 1e-7)
+  expect_equal(fdiv$FDiv, 0.7282172, tolerance = 1e-7)
 })
 
 test_that("Function Divergence works on subset of site/species", {
@@ -55,8 +55,10 @@ test_that("Functional Divergence works with sparse matrices", {
   expect_equal(nrow(fdiv), 1)
   expect_equal(colnames(fdiv), c("site", "FDiv"))
 
-  expect_equal(fd_fdiv(traits_birds, sparse_site_sp)$FDiv, 0.6011971,
-               tolerance = 1e-7)
+  expect_identical(
+    fd_fdiv(traits_birds, sparse_site_sp),
+    fd_fdiv(traits_birds, site_sp)
+  )
 
 })
 


### PR DESCRIPTION
Couple of comments in the edge cases:

- if the trait dataset has one column, the convex hull is taken as the range 
- if the trait dataset has not enough rows to compute the complex hull (e.g., 2 points to build a triangle), the gravity center G is computed on all the points instead of the vertices of the convex hull