### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-fric_intersect.R
+++ b/tests/testthat/test-fric_intersect.R
@@ -77,11 +77,11 @@ test_that("Functional Richness Intersection edge cases", {
     NA_real_
   )
 
-  expect_setequal(
-    expect_message(
-      fd_fric_intersect(traits_birds[1:4, ], site_sp_birds)[["FRic_intersect"]]
-    ),
-    NA_real_
+  expect_message(
+    expect_setequal(
+      fd_fric_intersect(traits_birds[1:4, ], site_sp_birds)[["FRic_intersect"]],
+      NA_real_
+    )
   )
 
   # Several species with similar trait values -> not enought species for FRic


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
