### PR TITLE
Add tests for non-numerical traits (fix #41)

### DIFF
--- a/R/fd_fdis.R
+++ b/R/fd_fdis.R
@@ -28,6 +28,13 @@ fd_fdis <- function(traits, sp_com) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
+  if ((is.matrix(traits) & !is.numeric(traits)) |
+      (is.data.frame(traits) &
+       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
+  }
+
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
   }

--- a/R/fd_fdis.R
+++ b/R/fd_fdis.R
@@ -28,15 +28,13 @@ fd_fdis <- function(traits, sp_com) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
-  if ((is.matrix(traits) & !is.numeric(traits)) |
-      (is.data.frame(traits) &
-       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   traits <- remove_species_without_trait(traits)

--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -28,6 +28,13 @@ fd_fdiv <- function(traits, sp_com) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
+  if ((is.matrix(traits) & !is.numeric(traits)) |
+      (is.data.frame(traits) &
+       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
+  }
+
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
   }

--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -28,15 +28,13 @@ fd_fdiv <- function(traits, sp_com) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
-  if ((is.matrix(traits) & !is.numeric(traits)) |
-      (is.data.frame(traits) &
-       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   traits <- remove_species_without_trait(traits)

--- a/R/fd_feve.R
+++ b/R/fd_feve.R
@@ -26,12 +26,21 @@
 #'
 #' @export
 fd_feve <- function(traits = NULL, sp_com, dist_matrix = NULL) {
+
   if ((!is.null(traits) & !is.null(dist_matrix)) |
       (is.null(traits) & is.null(dist_matrix))) {
     stop(
       "Please provide either a trait dataset or a dissimilarity matrix",
       call. = FALSE
     )
+  }
+
+  if (!is.null(traits) &
+        ((is.matrix(traits) & !is.numeric(traits)) |
+        (is.data.frame(traits) &
+        any(vapply(traits, function(x) !is.numeric(x), TRUE))))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   if (is.data.frame(traits) | is.vector(traits)) {

--- a/R/fd_feve.R
+++ b/R/fd_feve.R
@@ -35,16 +35,13 @@ fd_feve <- function(traits = NULL, sp_com, dist_matrix = NULL) {
     )
   }
 
-  if (!is.null(traits) &
-        ((is.matrix(traits) & !is.numeric(traits)) |
-        (is.data.frame(traits) &
-        any(vapply(traits, function(x) !is.numeric(x), TRUE))))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.null(traits) & !is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   if (is.null(dist_matrix)) {

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -55,15 +55,13 @@ fd_fric <- function(traits, sp_com, stand = FALSE) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
-  if ((is.matrix(traits) & !is.numeric(traits)) |
-      (is.data.frame(traits) &
-       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   if (ncol(traits) > 16) {

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -55,6 +55,13 @@ fd_fric <- function(traits, sp_com, stand = FALSE) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
+  if ((is.matrix(traits) & !is.numeric(traits)) |
+      (is.data.frame(traits) &
+       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
+  }
+
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
   }

--- a/R/fd_fric.R
+++ b/R/fd_fric.R
@@ -3,7 +3,10 @@
 #' Functional Richness is computed as the volume of the convex hull from all
 #' included traits.
 #'
-#' @param traits The matrix dataset for which you want to compute the index
+#' @param traits Trait matrix with species as rows and traits as columns.
+#'               It has to contain exclusively numerical values. This can be
+#'               either a `matrix`, a `data.frame`, or a [Matrix::Matrix()]
+#'               object.
 #' @param sp_com Site-species matrix with sites as rows and species as columns
 #'               if not provided, the function considers all species with equal
 #'               abundance in a single site. This can be either a `matrix`,

--- a/R/fd_fric_intersect.R
+++ b/R/fd_fric_intersect.R
@@ -36,15 +36,13 @@ fd_fric_intersect = function(traits, sp_com, stand = FALSE) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
-  if ((is.matrix(traits) & !is.numeric(traits)) |
-      (is.data.frame(traits) &
-       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   if (ncol(traits) > 16) {

--- a/R/fd_fric_intersect.R
+++ b/R/fd_fric_intersect.R
@@ -36,6 +36,13 @@ fd_fric_intersect = function(traits, sp_com, stand = FALSE) {
     stop("Please provide a trait dataset", call. = FALSE)
   }
 
+  if ((is.matrix(traits) & !is.numeric(traits)) |
+      (is.data.frame(traits) &
+       any(vapply(traits, function(x) !is.numeric(x), TRUE)))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
+  }
+
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
   }

--- a/R/fd_raoq.R
+++ b/R/fd_raoq.R
@@ -36,16 +36,13 @@ fd_raoq <- function(traits = NULL, sp_com, dist_matrix = NULL) {
     )
   }
 
-  if (!is.null(traits) &
-      ((is.matrix(traits) & !is.numeric(traits)) |
-       (is.data.frame(traits) &
-        any(vapply(traits, function(x) !is.numeric(x), TRUE))))) {
-    stop("Non-continuous trait data found in input traits. ",
-         "Please provide only continuous trait data", call. = FALSE)
-  }
-
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
+  }
+
+  if (!is.null(traits) & !is.numeric(traits)) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
   }
 
   if (is.null(dist_matrix)) {

--- a/R/fd_raoq.R
+++ b/R/fd_raoq.R
@@ -36,6 +36,14 @@ fd_raoq <- function(traits = NULL, sp_com, dist_matrix = NULL) {
     )
   }
 
+  if (!is.null(traits) &
+      ((is.matrix(traits) & !is.numeric(traits)) |
+       (is.data.frame(traits) &
+        any(vapply(traits, function(x) !is.numeric(x), TRUE))))) {
+    stop("Non-continuous trait data found in input traits. ",
+         "Please provide only continuous trait data", call. = FALSE)
+  }
+
   if (is.data.frame(traits) | is.vector(traits)) {
     traits <- as.matrix(traits)
   }

--- a/man/fd_fdis.Rd
+++ b/man/fd_fdis.Rd
@@ -7,7 +7,10 @@
 fd_fdis(traits, sp_com)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/man/fd_fdiv.Rd
+++ b/man/fd_fdiv.Rd
@@ -7,7 +7,10 @@
 fd_fdiv(traits, sp_com)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/man/fd_feve.Rd
+++ b/man/fd_feve.Rd
@@ -7,7 +7,10 @@
 fd_feve(traits = NULL, sp_com, dist_matrix = NULL)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/man/fd_fric.Rd
+++ b/man/fd_fric.Rd
@@ -7,7 +7,10 @@
 fd_fric(traits, sp_com, stand = FALSE)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/man/fd_fric_intersect.Rd
+++ b/man/fd_fric_intersect.Rd
@@ -7,7 +7,10 @@
 fd_fric_intersect(traits, sp_com, stand = FALSE)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/man/fd_raoq.Rd
+++ b/man/fd_raoq.Rd
@@ -7,7 +7,10 @@
 fd_raoq(traits = NULL, sp_com, dist_matrix = NULL)
 }
 \arguments{
-\item{traits}{The matrix dataset for which you want to compute the index}
+\item{traits}{Trait matrix with species as rows and traits as columns.
+It has to contain exclusively numerical values. This can be
+either a \code{matrix}, a \code{data.frame}, or a \code{\link[Matrix:Matrix]{Matrix::Matrix()}}
+object.}
 
 \item{sp_com}{Site-species matrix with sites as rows and species as columns
 if not provided, the function considers all species with equal

--- a/tests/testthat/test-fdis.R
+++ b/tests/testthat/test-fdis.R
@@ -101,7 +101,7 @@ test_that("Functional Dispersion fails gracefully", {
   # Categorical trait data
   expect_error(
     fd_fdis(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-fdis.R
+++ b/tests/testthat/test-fdis.R
@@ -1,8 +1,14 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 traits_birds_sc <- scale(traits_birds)
 
-# Actual tests
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds_sc)
+traits_birds_cat$cat_trait <- "a"
+
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Functional Dispersion output format", {
 
   fdis <- expect_silent(fd_fdis(traits_birds))
@@ -73,6 +79,9 @@ test_that("Functional Dispersion works with sparse matrices", {
 
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Functional Dispersion fails gracefully", {
 
   # No traits
@@ -88,4 +97,13 @@ test_that("Functional Dispersion fails gracefully", {
            "and site-species matrix"),
     fixed = TRUE
   )
+
+  # Categorical trait data
+  expect_error(
+    fd_fdis(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
+    fixed = TRUE
+  )
 })
+

--- a/tests/testthat/test-fdis.R
+++ b/tests/testthat/test-fdis.R
@@ -2,10 +2,6 @@
 data("traits_birds")
 traits_birds_sc <- scale(traits_birds)
 
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds_sc)
-traits_birds_cat$cat_trait <- "a"
-
 
 # Tests for valid inputs -------------------------------------------------------
 
@@ -98,7 +94,11 @@ test_that("Functional Dispersion fails gracefully", {
     fixed = TRUE
   )
 
-  # Categorical trait data
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds_sc)
+  traits_birds_cat$cat_trait <- "a"
+
   expect_error(
     fd_fdis(traits_birds_cat, site_sp_birds),
     paste0("Non-continuous trait data found in input traits. ",

--- a/tests/testthat/test-fdiv.R
+++ b/tests/testthat/test-fdiv.R
@@ -2,10 +2,6 @@
 data("traits_birds")
 traits_birds_sc <- scale(traits_birds)
 
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds_sc)
-traits_birds_cat$cat_trait <- "a"
-
 
 # Tests for valid inputs -------------------------------------------------------
 
@@ -98,7 +94,11 @@ test_that("Functional Divergence fails gracefully", {
     fixed = TRUE
   )
 
-  # Categorical trait data
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds_sc)
+  traits_birds_cat$cat_trait <- "a"
+
   expect_error(
     fd_fdiv(traits_birds_cat, site_sp_birds),
     paste0("Non-continuous trait data found in input traits. ",

--- a/tests/testthat/test-fdiv.R
+++ b/tests/testthat/test-fdiv.R
@@ -101,7 +101,7 @@ test_that("Functional Divergence fails gracefully", {
   # Categorical trait data
   expect_error(
     fd_fdiv(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-fdiv.R
+++ b/tests/testthat/test-fdiv.R
@@ -1,8 +1,14 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 traits_birds_sc <- scale(traits_birds)
 
-# Actual tests
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds_sc)
+traits_birds_cat$cat_trait <- "a"
+
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Functional Divergence output format", {
 
   fdiv <- expect_silent(fd_fdiv(traits_birds))
@@ -73,6 +79,9 @@ test_that("Functional Divergence works with sparse matrices", {
 
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Functional Divergence fails gracefully", {
 
   # No traits
@@ -86,6 +95,14 @@ test_that("Functional Divergence fails gracefully", {
     fd_fdiv(data.frame(a = 1, row.names = "sp1"), matrix(1)),
     paste0("No species in common found between trait dataset ",
            "and site-species matrix"),
+    fixed = TRUE
+  )
+
+  # Categorical trait data
+  expect_error(
+    fd_fdiv(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-feve.R
+++ b/tests/testthat/test-feve.R
@@ -152,7 +152,7 @@ test_that("Functional Evenness fails gracefully", {
   # Categorical trait data
   expect_error(
     fd_feve(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-feve.R
+++ b/tests/testthat/test-feve.R
@@ -1,9 +1,15 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 simple_site_sp <- matrix(1, nrow = 1, ncol = nrow(traits_birds),
                         dimnames = list("s1", row.names(traits_birds)))
 
-# Actual tests
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds_sc)
+traits_birds_cat$cat_trait <- "a"
+
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Functional Evenness output format", {
 
   feve <- expect_silent(fd_feve(traits_birds, sp_com = simple_site_sp))
@@ -117,6 +123,9 @@ test_that("Functional Evenness works on sparse matrices", {
     0.3743341, tolerance = 1e-6)
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Functional Evenness fails gracefully", {
   # No traits and no dissimilarity
   expect_error(
@@ -137,6 +146,14 @@ test_that("Functional Evenness fails gracefully", {
     fd_feve(data.frame(a = 1, row.names = "sp1"), matrix(1)),
     paste0("No species in common found between trait dataset ",
            "and site-species matrix"),
+    fixed = TRUE
+  )
+
+  # Categorical trait data
+  expect_error(
+    fd_feve(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-feve.R
+++ b/tests/testthat/test-feve.R
@@ -4,7 +4,7 @@ simple_site_sp <- matrix(1, nrow = 1, ncol = nrow(traits_birds),
                         dimnames = list("s1", row.names(traits_birds)))
 
 # Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds_sc)
+traits_birds_cat <- as.data.frame(traits_birds)
 traits_birds_cat$cat_trait <- "a"
 
 

--- a/tests/testthat/test-feve.R
+++ b/tests/testthat/test-feve.R
@@ -3,10 +3,6 @@ data("traits_birds")
 simple_site_sp <- matrix(1, nrow = 1, ncol = nrow(traits_birds),
                         dimnames = list("s1", row.names(traits_birds)))
 
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds)
-traits_birds_cat$cat_trait <- "a"
-
 
 # Tests for valid inputs -------------------------------------------------------
 
@@ -149,7 +145,11 @@ test_that("Functional Evenness fails gracefully", {
     fixed = TRUE
   )
 
-  # Categorical trait data
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds)
+  traits_birds_cat$cat_trait <- "a"
+
   expect_error(
     fd_feve(traits_birds_cat, site_sp_birds),
     paste0("Non-continuous trait data found in input traits. ",

--- a/tests/testthat/test-fric.R
+++ b/tests/testthat/test-fric.R
@@ -152,7 +152,7 @@ test_that("Functional Richness fails gracefully", {
 
   expect_error(
     fd_fric(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-fric.R
+++ b/tests/testthat/test-fric.R
@@ -1,7 +1,13 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 
-# Actual tests
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds)
+traits_birds_cat$cat_trait <- "a"
+
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Functional Richness output format", {
 
   fric <- expect_silent(fd_fric(traits_birds))
@@ -125,6 +131,9 @@ test_that("Functional Richness works on sparse matrices", {
                tolerance = 1e-6)
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Functional Richness fails gracefully", {
 
   # No traits
@@ -138,6 +147,13 @@ test_that("Functional Richness fails gracefully", {
     fd_fric(data.frame(a = 1, row.names = "sp1"), matrix(1)),
     paste0("No species in common found between trait dataset ",
            "and site-species matrix"),
+    fixed = TRUE
+  )
+
+  expect_error(
+    fd_fric(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-fric.R
+++ b/tests/testthat/test-fric.R
@@ -1,10 +1,6 @@
 # Preamble code ----------------------------------------------------------------
 data("traits_birds")
 
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds)
-traits_birds_cat$cat_trait <- "a"
-
 
 # Tests for valid inputs -------------------------------------------------------
 
@@ -149,6 +145,11 @@ test_that("Functional Richness fails gracefully", {
            "and site-species matrix"),
     fixed = TRUE
   )
+
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds)
+  traits_birds_cat$cat_trait <- "a"
 
   expect_error(
     fd_fric(traits_birds_cat, site_sp_birds),

--- a/tests/testthat/test-fric_intersect.R
+++ b/tests/testthat/test-fric_intersect.R
@@ -1,8 +1,14 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 data("site_sp_birds")
 
-# Actual tests
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds)
+traits_birds_cat$cat_trait <- "a"
+
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Functional Richness Intersection output format", {
 
   fric_int <- expect_silent(fd_fric_intersect(traits_birds))
@@ -149,6 +155,9 @@ test_that("Functional Richness Intersection works on sparse matrices", {
     1, tolerance = 1e-6)
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Functional Richness Intersection fails gracefully", {
 
   # No traits
@@ -162,6 +171,14 @@ test_that("Functional Richness Intersection fails gracefully", {
     fd_fric_intersect(data.frame(a = 1, row.names = "sp1"), matrix(1)),
     paste0("No species in common found between trait dataset ",
            "and site-species matrix"),
+    fixed = TRUE
+  )
+
+  # Categorical trait data
+  expect_error(
+    fd_fric_intersect(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-fric_intersect.R
+++ b/tests/testthat/test-fric_intersect.R
@@ -177,7 +177,7 @@ test_that("Functional Richness Intersection fails gracefully", {
   # Categorical trait data
   expect_error(
     fd_fric_intersect(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-fric_intersect.R
+++ b/tests/testthat/test-fric_intersect.R
@@ -2,10 +2,6 @@
 data("traits_birds")
 data("site_sp_birds")
 
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds)
-traits_birds_cat$cat_trait <- "a"
-
 
 # Tests for valid inputs -------------------------------------------------------
 
@@ -174,7 +170,11 @@ test_that("Functional Richness Intersection fails gracefully", {
     fixed = TRUE
   )
 
-  # Categorical trait data
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds)
+  traits_birds_cat$cat_trait <- "a"
+
   expect_error(
     fd_fric_intersect(traits_birds_cat, site_sp_birds),
     paste0("Non-continuous trait data found in input traits. ",

--- a/tests/testthat/test-raoq.R
+++ b/tests/testthat/test-raoq.R
@@ -2,9 +2,6 @@
 data("traits_birds")
 simple_site_sp <- matrix(1, nrow = 1, ncol = nrow(traits_birds),
                         dimnames = list("s1", row.names(traits_birds)))
-# Add non-continuous traits
-traits_birds_cat <- as.data.frame(traits_birds)
-traits_birds_cat$cat_trait <- "a"
 
 
 # Tests for valid inputs -------------------------------------------------------
@@ -126,6 +123,11 @@ test_that("Rao's entropy fails gracefully", {
            "and site-species matrix"),
     fixed = TRUE
   )
+
+  ## Categorical trait data
+  # Add non-continuous traits
+  traits_birds_cat <- as.data.frame(traits_birds)
+  traits_birds_cat$cat_trait <- "a"
 
   expect_error(
     fd_raoq(traits_birds_cat, site_sp_birds),

--- a/tests/testthat/test-raoq.R
+++ b/tests/testthat/test-raoq.R
@@ -129,7 +129,7 @@ test_that("Rao's entropy fails gracefully", {
 
   expect_error(
     fd_raoq(traits_birds_cat, site_sp_birds),
-    paste0("Non-continuous trait data found in input traits.",
+    paste0("Non-continuous trait data found in input traits. ",
            "Please provide only continuous trait data"),
     fixed = TRUE
   )

--- a/tests/testthat/test-raoq.R
+++ b/tests/testthat/test-raoq.R
@@ -1,9 +1,14 @@
-# Preamble code
+# Preamble code ----------------------------------------------------------------
 data("traits_birds")
 simple_site_sp <- matrix(1, nrow = 1, ncol = nrow(traits_birds),
                         dimnames = list("s1", row.names(traits_birds)))
+# Add non-continuous traits
+traits_birds_cat <- as.data.frame(traits_birds)
+traits_birds_cat$cat_trait <- "a"
 
-# Actual tests
+
+# Tests for valid inputs -------------------------------------------------------
+
 test_that("Rao's entropy output format", {
 
   rq <- expect_silent(fd_raoq(traits_birds, sp_com = simple_site_sp))
@@ -96,6 +101,9 @@ test_that("Rao's Quadratic Entropy works on sparse matrices", {
 
 })
 
+
+# Tests for invalid inputs -----------------------------------------------------
+
 test_that("Rao's entropy fails gracefully", {
   # No traits and no dissimilarity
   expect_error(
@@ -116,6 +124,13 @@ test_that("Rao's entropy fails gracefully", {
     fd_raoq(data.frame(a = 1, row.names = "sp1"), matrix(1)),
     paste0("No species in common found between trait dataset ",
            "and site-species matrix"),
+    fixed = TRUE
+  )
+
+  expect_error(
+    fd_raoq(traits_birds_cat, site_sp_birds),
+    paste0("Non-continuous trait data found in input traits.",
+           "Please provide only continuous trait data"),
     fixed = TRUE
   )
 })


### PR DESCRIPTION
This PR aims to fix #41 by testing explicitly the behavior of the diversity functions with non-numerical trait data.

It also implements corresponding errors for non-numerical traits.