### PR TITLE
Get FDiv to work on matrices without rownames

### DIFF
--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -48,6 +48,9 @@ fd_fdiv <- function(traits, sp_com) {
 
   } else {
 
+    # We may override actual species names but we don't care because species
+    # identity doesn't matter when no species-site matrix is provided.
+    rownames(traits) <- paste0("sp", seq_len(nrow(traits)))
     sp_com <- matrix(1, ncol = nrow(traits),
                      dimnames = list("s1", rownames(traits)))
 

--- a/R/fd_fdiv.R
+++ b/R/fd_fdiv.R
@@ -48,9 +48,9 @@ fd_fdiv <- function(traits, sp_com) {
 
   } else {
 
-    # We may override actual species names but we don't care because species
-    # identity doesn't matter when no species-site matrix is provided.
-    rownames(traits) <- paste0("sp", seq_len(nrow(traits)))
+    if (is.null(rownames(traits))) {
+      rownames(traits) <- paste0("sp", seq_len(nrow(traits)))
+   }
     sp_com <- matrix(1, ncol = nrow(traits),
                      dimnames = list("s1", rownames(traits)))
 

--- a/tests/testthat/test-fdiv.R
+++ b/tests/testthat/test-fdiv.R
@@ -75,6 +75,17 @@ test_that("Functional Divergence works with sparse matrices", {
 
 })
 
+test_that("Functional Divergence works with matrices without rownames", {
+
+  traits_birds_un <- traits_birds
+  rownames(traits_birds_un) <- NULL
+
+  expect_identical(
+    fd_fdiv(traits_birds_un),
+    fd_fdiv(traits_birds)
+  )
+
+})
 
 # Tests for invalid inputs -----------------------------------------------------
 


### PR DESCRIPTION
Fix #55 